### PR TITLE
Fix installation with `package-vc-install` for Emacs 29: add package metadata

### DIFF
--- a/edraw.el
+++ b/edraw.el
@@ -3,7 +3,11 @@
 ;; Copyright (C) 2021 AKIYAMA Kouhei
 
 ;; Author: AKIYAMA Kouhei <misohena@gmail.com>
+;; Homepage: https://github.com/misohena/el-easydraw
 ;; Keywords: Graphics,Drawing,SVG
+
+;; Package-Version: 1.0.1
+;; Package-Requires: ((emacs "27.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -3871,7 +3875,7 @@ position where the EVENT occurred."
 
 (cl-defmethod edraw-set-rect ((shape edraw-shape-with-rect-boundary) xy0 xy1)
   (edraw-make-anchor-points-from-element shape) ;;Make sure p0p1 is initialized
-  ;;@todo 
+  ;;@todo
   (with-slots (p0p1) shape
     (when (or (/= (caar p0p1) (car xy0))
               (/= (cdar p0p1) (cdr xy0))


### PR DESCRIPTION
Emacs version 29 added the ability to install packages from source, with `package-vc-install`.
Attempting to install it this way:

```elisp
(package-vc-install "https://github.com/misohena/el-easydraw" 'edraw)
```

Gives the error message "Version must be a string". In fact, there is no package version indicated in [edraw.el](https://github.com/misohena/el-easydraw/blob/master/edraw.el).

This PR adds the necessary information (i.e. package version) to be able to install with `package-vc-install`, and some other metadata mentioned by [`package-lint`](https://github.com/purcell/package-lint).

You can test the installation before merging with:

```elisp
(package-vc-install "https://github.com/thezeroalpha/el-easydraw" 'edraw "add-package-version")
```