### PR TITLE
Fix #23. Make comma-wsp optional in path descriptors.

### DIFF
--- a/edraw-path.el
+++ b/edraw-path.el
@@ -2465,9 +2465,8 @@ bezier curve line: [(x0 . y0) (x1 . y1) (x2 . y2) (x3 . y3)]
 ;; Path Data Syntax
 ;; https://www.w3.org/TR/SVG11/paths.html#PathDataBNF
 
-(defconst edraw-path-d-abs-number "\\(?:\\(?:[0-9]+\\(?:\\.[0-9]*\\)?\\|\\.[0-9]+\\)\\(?:[eE][-+]?[0-9]+\\)?\\)")
 (defconst edraw-path-d-number
-  (format "\\(?:[-+]?%s\\)" edraw-path-d-abs-number))
+  "\\(?:[-+]?\\(?:[0-9]+\\(?:\\.[0-9]*\\)?\\|\\.[0-9]+\\)\\(?:[eE][-+]?[0-9]+\\)?\\)")
 (defconst edraw-path-d-wsp "\\(?:[ \t\n\f\r]+\\)")
 (defconst edraw-path-d-wsp-opt "[ \t\n\f\r]*")
 (defconst edraw-path-d-comma-wsp "\\(?:[ \t\n\f\r]+,?[ \t\n\f\r]*\\|,[ \t\n\f\r]*\\)")
@@ -2477,17 +2476,15 @@ bezier curve line: [(x0 . y0) (x1 . y1) (x2 . y2) (x3 . y3)]
    "\\([A-Z]\\)" ;; (1) command type
    "\\(?:" edraw-path-d-wsp-opt
    "\\(" edraw-path-d-number ;;(2) command arguments
-   "\\(?:" edraw-path-d-comma-wsp edraw-path-d-number "\\|[+-]" edraw-path-d-abs-number "\\)*\\)" "\\)?"
-   edraw-path-d-comma-wsp "?"))
+   "\\(?:" edraw-path-d-comma-wsp "?" edraw-path-d-number "\\)*\\)" "\\)?"
+   edraw-path-d-wsp "?"))
 
 (defun edraw-path-d-split-numbers-str (numbers-str)
   "Split NUMBERS-STR into a list of number strings."
   (let (ret pos)
     (while (string-match edraw-path-d-number numbers-str pos)
       (setq pos (match-end 0))
-      (push (match-string 0 numbers-str) ret)
-      (when (eq pos (string-match edraw-path-d-comma-wsp numbers-str pos))
-	(setq pos (match-end 0))))
+      (push (match-string 0 numbers-str) ret))
     (nreverse ret)))
 
 (defun edraw-path-d-parse (d)
@@ -2496,7 +2493,7 @@ bezier curve line: [(x0 . y0) (x1 . y1) (x2 . y2) (x3 . y3)]
         commands)
     (while (string-match edraw-path-d-command d pos)
       (when (/= (match-beginning 0) pos)
-        (error "path data parsing error at %s" (substring d pos)))
+        (error "Path data parsing error at %s" (substring d pos)))
       (setq pos (match-end 0))
       (let* ((type (intern (match-string 1 d)))
              (numbers-str (match-string 2 d))
@@ -2507,7 +2504,7 @@ bezier curve line: [(x0 . y0) (x1 . y1) (x2 . y2) (x3 . y3)]
     (nreverse commands)))
 ;; TEST: (edraw-path-d-parse "Z M 10 20.1 L .1 2e+1 20e1 -5e-1") => ((Z) (M 10.0 20.1) (L 0.1 20.0 200.0 -0.5))
 ;; TEST: (edraw-path-d-parse "ZM10 20.1L.1 2e+1 20e1 -5e-1") => ((Z) (M 10.0 20.1) (L 0.1 20.0 200.0 -0.5))
-;; TEST: (edraw-path-d-parse "ZM10 20.1L.1-2e+1 20e1-5e-1") => ((Z) (M 10.0 20.1) (L 0.1 -20.0 200.0 -0.5))
+;; TEST: (edraw-path-d-parse "ZM10 20.1L.1-2e+1 20e1.5e-1") => ((Z) (M 10.0 20.1) (L 0.1 -20.0 200.0 0.05))
 
 (defun edraw-path-d-from-command-list (command-list)
   (mapconcat (lambda (command)

--- a/edraw.el
+++ b/edraw.el
@@ -748,7 +748,14 @@ edraw-editor initialization is now called automatically."
   ;;   ...)
   ;;
   ;; However, interactive can be specified.
-  (declare (indent 2))
+  (declare (indent 2) (debug
+		       (&define                    ; this means we are defining something
+			[&name [sexp   ;Allow (setf ...) additionally to symbols.
+				[&rest cl-generic--method-qualifier-p] ;qualifiers
+				listp]             ; arguments
+			       cl--generic-edebug-make-name nil]
+			lambda-doc                 ; documentation string
+			def-body)))
   (unless (equal (car arg-list) '(editor edraw-editor))
     (error "Defcmd's argument list must start with (editor edraw-editor)"))
 
@@ -903,7 +910,7 @@ This function deletes all redo data."
 ;; No Undo Data
 
 (defmacro edraw-editor-with-no-undo-data (&rest body)
-  (declare (indent 0))
+  (declare (indent 0) (debug (body)))
   `(let ((edraw-editor-inhibit-make-undo-data t))
      ,@body))
 
@@ -930,7 +937,7 @@ This function deletes all redo data."
 
 (defmacro edraw-make-undo-group (editor type &rest body)
   "Combine undo data pushed in BODY into one."
-  (declare (indent 2))
+  (declare (indent 2) (debug (sexp sexp body)))
   (let ((var-old-undo-list (gensym))
         (var-editor (gensym))
         (var-data (gensym)))
@@ -1012,7 +1019,7 @@ For use with `edraw-editor-with-temp-undo-list',
 
 (defmacro edraw-editor-with-temp-undo-list (editor &rest body)
   "Evaluate the BODY under a new independent undo list."
-  (declare (indent 1))
+  (declare (indent 1) (debug (sexp body)))
   ;;@todo Increase undo limit?
   (let ((sym-editor (gensym 'editor-))
         (sym-old-undo-list (gensym 'old-undo-list-))
@@ -1030,7 +1037,7 @@ For use with `edraw-editor-with-temp-undo-list',
 
 (defmacro edraw-editor-with-temp-modifications (editor &rest body)
   "Evaluate BODY and then execute all UNDO data recorded in EDITOR."
-  (declare (indent 1))
+  (declare (indent 1) (debug (sexp body)))
   (let ((sym-editor (gensym 'editor-)))
     `(let ((,sym-editor ,editor)
            (edraw-editor-inhibit-make-undo-data nil) ;; Record undo data
@@ -1168,7 +1175,7 @@ For use with `edraw-editor-with-temp-undo-list',
     modified-p))
 
 (defmacro edraw-editor-with-silent-modifications (&rest body)
-  (declare (indent 0))
+  (declare (indent 0) (debug (body)))
   `(let ((edraw-editor-inhibit-make-undo-data t)
          (edraw-editor-keep-modified-flag t))
      ,@body))
@@ -1554,6 +1561,7 @@ For use with `edraw-editor-with-temp-undo-list',
     (list origin-xy sx sy)))
 
 (defmacro edraw-set-scale-params (aabb-expr)
+  (declare (debug (sexp)))
   `(let ((result (edraw-read-scale-params ,aabb-expr origin-xy sx sy)))
      (setq origin-xy (nth 0 result)
            sx (nth 1 result)
@@ -1585,6 +1593,7 @@ For use with `edraw-editor-with-temp-undo-list',
     (list origin-xy angle)))
 
 (defmacro edraw-set-rotate-params (aabb-expr)
+  (declare (debug (sexp)))
   `(let ((result (edraw-read-rotate-params ,aabb-expr origin-xy angle)))
      (setq origin-xy (nth 0 result)
            angle (nth 1 result))))


### PR DESCRIPTION
Make comma-wsp optional in path descriptors.
Along the way, add some debug declarations on macros.