### PR TITLE
Fixes #25 zoom scroll imported image

### DIFF
--- a/edraw-dom-svg.el
+++ b/edraw-dom-svg.el
@@ -271,6 +271,17 @@ Attribute value is preserved."
       (setcdr cell (cons child (cdr cell)))))
   child)
 
+(defun edraw-dom-wrap-children-by-new-node (tag attributes children)
+  "Replace the list of CHILDREN with a list containing a single new NODE.
+NODE is constructed from TAG and ATTRIBUTES by `dom-node'
+and gets the original CHILDREN.
+Return the new node."
+  ;; depends on dom.el node structure
+  (let ((new-head (cons (car children) (cdr children))))
+    (setcar children (apply #'dom-node tag attributes new-head))
+    (setcdr children nil)
+    (car children)))
+;; Test: (edraw-dom-wrap-children-by-new-node 'g '((id . "edraw-body")) '((g (id . "page 1") (path (d . "first")) (path (d . "second")))))
 
 ;;;; SVG Print
 

--- a/edraw.el
+++ b/edraw.el
@@ -1110,8 +1110,9 @@ For use with `edraw-editor-with-temp-undo-list',
     ;; #edraw-body
     (unless (edraw-dom-get-by-id svg edraw-editor-svg-body-id)
       (edraw-dom-wrap-children-by-new-node
+       svg
        'g
-       (list (cons 'id edraw-editor-svg-body-id))
+       (list :id edraw-editor-svg-body-id)
        (cdr (dom-children svg)) ;; skip defs
        ))
 

--- a/edraw.el
+++ b/edraw.el
@@ -1108,7 +1108,12 @@ For use with `edraw-editor-with-temp-undo-list',
                               (edraw-svg-defrefs-defs-element defrefs)))
 
     ;; #edraw-body
-    (edraw-dom-get-or-create svg 'g edraw-editor-svg-body-id)
+    (unless (edraw-dom-get-by-id svg edraw-editor-svg-body-id)
+      (edraw-dom-wrap-children-by-new-node
+       'g
+       (list (cons 'id edraw-editor-svg-body-id))
+       (cdr (dom-children svg)) ;; skip defs
+       ))
 
     ;; Restore Point Connections
     (edraw-restore-point-connections editor)))


### PR DESCRIPTION
Wrap the old contents of the imported SVG with group `edraw-body` instead of adding an empty group `edraw-body`.

Dear @misohena , this is just a suggestion you can improve it or change it to your liking.

An interesting alternative would be using the viewport-attribute of the SVG image to scroll and scale the view instead of the transformation of group `edraw-body`.